### PR TITLE
Remove check key already taken

### DIFF
--- a/backend/app/api/routes/experiments.py
+++ b/backend/app/api/routes/experiments.py
@@ -162,7 +162,6 @@ async def update_experiment_by_id(
                     collaborators_repo=collaborators_repo,
                     users_repo=users_repo,
                 )
-
     experiment_update = ExperimentUpdate(**experiment_full_update.dict(exclude_unset=True))
     experiment = await experiments_repo.update_experiment_by_id(id_exp=id, experiment_update=experiment_update)
 
@@ -239,18 +238,6 @@ async def join_experiment_by_id(
 
     whitelist_item = None
     for whitelist_item_tmp in all_experiment_id_items:
-        collaborators_list = await collaborators_repo.list_all_collaborator_by_whitelist_item_id(
-            whitelist_item_id=whitelist_item_tmp.id
-        )
-
-        # Check if a collaborator in the same experiment hasn't already use the same public key
-        for collaborator in collaborators_list:
-            if collaborator and collaborator.peer_public_key == experiment_join_input.peer_public_key:
-                raise HTTPException(
-                    status_code=HTTP_401_UNAUTHORIZED,
-                    detail="Access to the experiment denied, the public key is already taken.",
-                )
-
         user_db = await users_repo.get_user_by_id(id=whitelist_item_tmp.user_id)
 
         if user_db.username == user.username:

--- a/backend/tests/test_experiments.py
+++ b/backend/tests/test_experiments.py
@@ -438,6 +438,106 @@ class TestJoinExperiment:
         assert public_key_1_found
         assert public_key_2_found
 
+    async def test_can_join_experiment_successfully_2_times_with_same_public_key(
+        self,
+        moonlanding_user_1,
+        moonlanding_user_2,
+        app: FastAPI,
+        client_wt_auth_user_1: AsyncClient,
+        # client_wt_auth_user_2: AsyncClient,
+        test_experiment_1_created_by_user_2: ExperimentFullPublic,
+        test_experiment_join_input_1_by_user_1: ExperimentJoinInput,
+    ) -> None:
+        values = test_experiment_join_input_1_by_user_1.dict()
+        # Make the values JSON serializable
+        values["peer_public_key"] = values["peer_public_key"].decode("utf-8")
+
+        res = await client_wt_auth_user_1.put(
+            app.url_path_for("experiments:join-experiment-by-id", id=test_experiment_1_created_by_user_2.id),
+            json={"experiment_join_input": values},
+        )
+        assert res.status_code == status.HTTP_200_OK, res.content
+
+        exp_pass = ExperimentJoinOutput(**res.json())
+        assert getattr(exp_pass, "coordinator_ip") == test_experiment_1_created_by_user_2.coordinator_ip
+        assert getattr(exp_pass, "coordinator_port") == test_experiment_1_created_by_user_2.coordinator_port
+
+        hivemind_access = getattr(exp_pass, "hivemind_access")
+        assert getattr(hivemind_access, "peer_public_key") == test_experiment_join_input_1_by_user_1.peer_public_key
+
+        signature = base64.b64decode(getattr(hivemind_access, "signature"))
+
+        auth_server_public_key = getattr(exp_pass, "auth_server_public_key")
+        auth_server_public_key = crypto.load_public_key(auth_server_public_key)
+
+        verif = auth_server_public_key.verify(
+            signature,
+            f"{hivemind_access.username} {hivemind_access.peer_public_key} {hivemind_access.expiration_time}".encode(),
+            crypto.PADDING,
+            crypto.HASH_ALGORITHM,
+        )
+        assert verif is None  # verify() returns None iff the signature is correct
+        assert hivemind_access.expiration_time > datetime.datetime.utcnow()
+        assert hivemind_access.username == moonlanding_user_1.username
+
+        # Now the same user try to join a second time with another public key
+        values = test_experiment_join_input_1_by_user_1.dict()
+        # Make the values JSON serializable
+        values["peer_public_key"] = values["peer_public_key"].decode("utf-8")
+
+        res = await client_wt_auth_user_1.put(
+            app.url_path_for("experiments:join-experiment-by-id", id=test_experiment_1_created_by_user_2.id),
+            json={"experiment_join_input": values},
+        )
+        assert res.status_code == status.HTTP_200_OK, res.content
+
+        exp_pass = ExperimentJoinOutput(**res.json())
+        assert getattr(exp_pass, "coordinator_ip") == test_experiment_1_created_by_user_2.coordinator_ip
+        assert getattr(exp_pass, "coordinator_port") == test_experiment_1_created_by_user_2.coordinator_port
+
+        hivemind_access = getattr(exp_pass, "hivemind_access")
+        assert getattr(hivemind_access, "peer_public_key") == test_experiment_join_input_1_by_user_1.peer_public_key
+
+        signature = base64.b64decode(getattr(hivemind_access, "signature"))
+
+        auth_server_public_key = getattr(exp_pass, "auth_server_public_key")
+        auth_server_public_key = crypto.load_public_key(auth_server_public_key)
+
+        verif = auth_server_public_key.verify(
+            signature,
+            f"{hivemind_access.username} {hivemind_access.peer_public_key} {hivemind_access.expiration_time}".encode(),
+            crypto.PADDING,
+            crypto.HASH_ALGORITHM,
+        )
+        assert verif is None  # verify() returns None iff the signature is correct
+        assert hivemind_access.expiration_time > datetime.datetime.utcnow()
+        assert hivemind_access.username == moonlanding_user_1.username
+
+        # Verify if the 2 public keys have been saved in DB
+
+        app.dependency_overrides[authenticate] = lambda: moonlanding_user_2
+
+        res = await client_wt_auth_user_1.get(
+            app.url_path_for("experiments:get-experiment-by-id", id=test_experiment_1_created_by_user_2.id)
+        )
+        assert res.status_code == status.HTTP_200_OK
+        experiment = ExperimentFullPublic(**res.json())
+
+        username_found = False
+        public_key_found = 0
+
+        collaborators_list = experiment.collaborators
+        for collaborator in collaborators_list:
+            if (
+                collaborator.username == moonlanding_user_1.username
+                and collaborator.peer_public_key == test_experiment_join_input_1_by_user_1.peer_public_key
+            ):
+                username_found = True
+                public_key_found += 1
+
+        assert username_found
+        assert public_key_found == 2
+
     async def test_cant_join_experiment_successfully_user_not_whitelisted(
         self,
         moonlanding_user_1,


### PR DESCRIPTION
@borzunov needs the option, that checks that the peer public key is not already in use, to be removed