### PR TITLE
Updating dependency versions to avoid vulnerabilities

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,7 +1,7 @@
 # app
-fastapi==0.55.1
-uvicorn==0.11.3
-pydantic==1.4
+fastapi>=0.65.2
+uvicorn>=0.11.7
+pydantic>=1.6.2
 email-validator==1.1.1
 
 #auth


### PR DESCRIPTION
This PR changes the versions of the `fastapi`, `uvicorn` and `pydantic` packages which presented several risks.