### PR TITLE
🔒 Pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/code_quality.yml
+++ b/.github/workflows/code_quality.yml
@@ -15,9 +15,9 @@ jobs:
         name: Check code quality
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@v2
+            - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
             - name: Set up Python 3.8
-              uses: actions/setup-python@v2
+              uses: actions/setup-python@e9aba2c848f5ebd159c070c61ea2c4e2b122355e  # v2
               with:
                   python-version: 3.8
             - name: Install dependencies


### PR DESCRIPTION
## 🔒 Pin GitHub Actions to commit SHAs

This PR pins all GitHub Actions to their exact commit SHA instead of mutable tags or branch names.

**Why?**
Pinning to a SHA prevents supply chain attacks where a tag (e.g. `v4`) could be moved to point to malicious code.

### Changes

| Workflow | Action | Avant | Après | SHA |
|---|---|---|---|---|
| `code_quality.yml` | `actions/checkout` | `v2` | `v6.0.2` | `de0fac2e4500…` |
| `code_quality.yml` | `actions/setup-python` | `v2` | `v2` | `e9aba2c848f5…` |

> 🤖 Generated by `/github-actions-audit` — [security/pin-actions-to-sha]


Closes huggingface/tracking-issues#81